### PR TITLE
Update ring-virtual-alarm-hub.groovy

### DIFF
--- a/src/drivers/ring-virtual-alarm-hub.groovy
+++ b/src/drivers/ring-virtual-alarm-hub.groovy
@@ -323,7 +323,7 @@ def setValues(deviceInfo) {
     if (nw.ppp0) {
       sendEvent(name: nw.ppp0.type.capitalize(), value: "${nw.ppp0.name} RSSI ${nw.ppp0.rssi}")
     }
-    if (nw.wlan0) {
+    if (nw.wlan0.type != null) {
       sendEvent(name: nw.wlan0.type.capitalize(), value: "${nw.wlan0.ssid} RSSI ${nw.wlan0.rssi}")
     }
   }


### PR DESCRIPTION
Fixing a recent error where Ring can report back with a nw.wlan0.type = null, so added to the check to make sure there is a type, not just an existence of wlan0.
Been running this for a few weeks with no negative impact, just one less error showing up in HE.