### PR TITLE
Improve watchdog reliability. Add panic button driver. Simplify some code repetition 

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,6 @@
 {
   "packageName": "Hubitat Ring Integration (Unofficial)",
   "author": "codahq",
-
   "version": "0.3.7",
   "minimumHEVersion": "0.0",
   "dateReleased": "2021-08-16",
@@ -177,6 +176,13 @@
       "name": "Ring Virtual Switch",
       "namespace": "ring-hubitat-codahq",
       "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-switch.groovy",
+      "required": false
+    },
+    {
+      "id": "d010d9fa-653d-4c48-aa0e-dad26d65d7ee",
+      "name": "Ring Virtual Panic BUtton",
+      "namespace": "ring-hubitat-codahq",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-panic-button.groovy",
       "required": false
     }
   ],

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,19 +1,20 @@
 {
   "packageName": "Hubitat Ring Integration (Unofficial)",
   "author": "codahq",
-  "version": "0.3.6",
+
+  "version": "0.3.7",
   "minimumHEVersion": "0.0",
-  "dateReleased": "2021-08-07",
-  "releaseNotes": "Add new devices, fix location API call",
+  "dateReleased": "2021-08-16",
+  "releaseNotes": "Improve robustness of connection watchdog",
   "apps": [
     {
       "id": "981fa0e5-b7c7-4459-a9ba-7ccdc51faa55",
       "name": "Unofficial Ring Connect",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/apps/unofficial-ring-connect.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/apps/unofficial-ring-connect.groovy",
       "required": true,
       "oauth": true,
-      "version": "0.3.6"
+      "version": "0.3.7"
     }
   ],
   "drivers": [
@@ -21,163 +22,163 @@
       "id": "8f216a41-8eed-4246-8c83-f45e45d36967",
       "name": "Ring API Virtual Device",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-api-virtual-device.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-api-virtual-device.groovy",
       "required": true
     },
     {
       "id": "5bcdd988-ccec-4f4b-9fc1-90d820fda1af",
       "name": "Ring Virtual Alarm Hub",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-alarm-hub.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-alarm-hub.groovy",
       "required": false
     },
     {
       "id": "70efa457-42eb-46ac-99f7-095a5e313149",
       "name": "Ring Virtual Alarm Range Extender",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-alarm-range-extender.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-alarm-range-extender.groovy",
       "required": false
     },
     {
       "id": "aead008c-f3f5-4ffd-b936-a5803213768f",
       "name": "Ring Virtual Alarm Smoke & CO Listener",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-alarm-smoke-co-listener.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-alarm-smoke-co-listener.groovy",
       "required": false
     },
     {
       "id": "d8892a22-34a9-47d8-893d-a69bb24c756d",
       "name": "Ring Virtual Beams Bridge",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-beams-bridge.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-beams-bridge.groovy",
       "required": false
     },
     {
       "id": "79d7248b-7db9-4b05-8f67-6c53e22662ee",
       "name": "Ring Virtual Beams Group",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-beams-group.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-beams-group.groovy",
       "required": false
     },
     {
       "id": "e27d6c9b-7442-4828-9d24-ca019939f524",
       "name": "Ring Virtual Beams Light",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-beams-light.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-beams-light.groovy",
       "required": false
     },
     {
       "id": "02be7aac-42b4-4ae8-b08e-89148dea5565",
       "name": "Ring Virtual Beams Motion Sensor",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-beams-motion-sensor.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-beams-motion-sensor.groovy",
       "required": false
     },
     {
       "id": "69752fc9-099d-4cb9-a7ae-af50a4e9f238",
       "name": "Ring Virtual Camera",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-camera.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-camera.groovy",
       "required": false
     },
     {
       "id": "0971b13a-e3e3-43e6-b02f-b5d384db5a46",
       "name": "Ring Virtual Camera with Siren",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-camera-with-siren.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-camera-with-siren.groovy",
       "required": false
     },
     {
       "id": "2bbff10b-0231-47d3-bb80-25d86d1a2317",
       "name": "Ring Virtual Chime",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-chime.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-chime.groovy",
       "required": false
     },
     {
       "id": "bca84b7f-a3ee-4464-bee7-47313fdc06de",
       "name": "Ring Virtual CO Alarm",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-co-alarm.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-co-alarm.groovy",
       "required": false
     },
     {
       "id": "a64d3760-5873-4f65-8dc8-a67d23fc835c",
       "name": "Ring Virtual Contact Sensor",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-contact-sensor.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-contact-sensor.groovy",
       "required": false
     },
     {
       "id": "32b9f95d-1d97-4ae9-a59c-69bbb5d806a2",
       "name": "Ring Virtual Alarm Flood & Freeze Sensor",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-flood-freeze-sensor.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-flood-freeze-sensor.groovy",
       "required": false
     },
     {
       "id": "9d755c96-7282-4650-9eb0-a18fb918af2a",
       "name": "Ring Virtual Keypad",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-keypad.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-keypad.groovy",
       "required": false
     },
     {
       "id": "0535ca0b-f816-411d-ace1-0febf3da27b6",
       "name": "Ring Virtual Light",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-light.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-light.groovy",
       "required": false
     },
     {
       "id": "daea57e4-1600-404b-b58c-223ea870760b",
       "name": "Ring Virtual Light with Siren",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-light-with-siren.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-light-with-siren.groovy",
       "required": false
     },
     {
       "id": "9e38ce3c-a7ea-4db0-b82b-bf9d1772248d",
       "name": "Ring Virtual Lock",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-lock.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-lock.groovy",
       "required": false
     },
     {
       "id": "0d140155-f66a-49b1-86f4-695877a744d6",
       "name": "Ring Virtual Motion Sensor",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-motion-sensor.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-motion-sensor.groovy",
       "required": false
     },
     {
       "id": "bdb8b6e7-de9c-45e9-a286-6493fcebe4e5",
       "name": "Ring Virtual Retrofit Alarm Kit",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-retrofit-alarm-kit.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-retrofit-alarm-kit.groovy",
       "required": false
     },
     {
       "id": "f65782ac-e70b-42dc-b6b6-90f75fd903ae",
       "name": "Ring Virtual Siren",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-siren.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-siren.groovy",
       "required": false
     },
     {
       "id": "a023f88d-63df-46f4-8c3c-6aee94b7dce2",
       "name": "Ring Virtual Smoke Alarm",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-smoke-alarm.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-smoke-alarm.groovy",
       "required": false
     },
     {
       "id": "b7fa1b23-96d9-4407-8896-3b4af7372fc4",
       "name": "Ring Virtual Switch",
       "namespace": "ring-hubitat-codahq",
-      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.6/src/drivers/ring-virtual-switch.groovy",
+      "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitat_ring_integration/v0.3.7/src/drivers/ring-virtual-switch.groovy",
       "required": false
     }
   ],
-  "documentationLink": "https://github.com/HubitatCommunity/hubitat_ring_integration/blob/v0.3.6/README.md"
+  "documentationLink": "https://github.com/HubitatCommunity/hubitat_ring_integration/blob/v0.3.7/README.md"
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -5,7 +5,7 @@
   "version": "0.3.7",
   "minimumHEVersion": "0.0",
   "dateReleased": "2021-08-16",
-  "releaseNotes": "Improve robustness of connection watchdog",
+  "releaseNotes": "Improve robustness of connection watchdog. Remove unnecessary safe object traversal. Reduce repetition in the code",
   "apps": [
     {
       "id": "981fa0e5-b7c7-4459-a9ba-7ccdc51faa55",

--- a/src/drivers/ring-api-virtual-device.groovy
+++ b/src/drivers/ring-api-virtual-device.groovy
@@ -29,6 +29,8 @@
  *              Optimization around uncreated devices
  *  2020-12-01: Fix bug with how device data fields are set. Caused device commands to fail in hubitat v2.2.4
  *  2021-08-16: Watchdog is now based on receipt of websocket messages. Should make reconnection more robust
+ *              Remove unnecessary safe object traversal
+ *              Reduce repetition in some of the code
  */
 
 import groovy.json.JsonSlurper
@@ -612,143 +614,106 @@ def extractDeviceInfos(json) {
 
   def deviceInfos = []
 
-  def orig = json
-
-  def jsonSlurper = new JsonSlurper()
-  def jsonString = '''
-{
-"deviceType": ""
-}
-'''
-
   //"lastUpdate": "",
   //"contact": "closed",
   //"motion": "inactive"
 
-  def returnResult = jsonSlurper.parseText(jsonString)
-
-  returnResult.src = json.src
-  returnResult.msg = json.msg
+  def defaultDeviceInfo = [
+    deviceType: '',
+    src: json.src,
+    msg: json.msg,
+  ]
 
   if (json.context) {
-    def tmpContext = json.context
-    returnResult.eventOccurredTsMs = tmpContext.eventOccurredTsMs
-    returnResult.level = tmpContext.eventLevel
-    returnResult.affectedEntityType = tmpContext.affectedEntityType
-    returnResult.affectedEntityId = tmpContext.affectedEntityId
-    returnResult.affectedEntityName = tmpContext.affectedEntityName
-    returnResult.accountId = tmpContext.accountId
-    returnResult.assetId = tmpContext.assetId
-    returnResult.assetKind = tmpContext.assetKind
+    List keys = ['accountId', 'affectedEntityType', 'affectedEntityId', 'affectedEntityName', 'assetId', 'assetKind', 'eventOccurredTsMs']
+    for (key in keys) {
+      defaultDeviceInfo[key] = json.context[key]
+    }
+
+    defaultDeviceInfo.level = json.context.eventLevel
   }
 
   //iterate each device
   json.body.each {
-    def copy = new JsonSlurper().parseText(JsonOutput.toJson(returnResult))
+    def curDeviceInfo = defaultDeviceInfo.clone()
 
     def deviceJson = it
     //logTrace "now deviceJson: ${JsonOutput.prettyPrint(JsonOutput.toJson(deviceJson))}"
     if (!deviceJson) {
-      deviceInfos << copy
+      deviceInfos << curDeviceInfo
     }
 
-    if (deviceJson.general) {
-      def tmpGeneral
-      if (deviceJson.general.v1) {
-        tmpGeneral = deviceJson.general.v1
+    if (deviceJson?.general) {
+      def tmpGeneral = deviceJson.general?.v1 ?: deviceJson.general?.v2
+
+      List keys = ['acStatus', 'adapterType', 'batteryLevel', 'batteryStatus', 'deviceType', 'fingerprint', 'lastUpdate',
+                   'lastCommTime', 'manufacturerName', 'name', 'nextExpectedWakeup', 'roomId', 'serialNumber', 'tamperStatus', 'zid']
+      for (key in keys) {
+        curDeviceInfo[key] = tmpGeneral[key]
       }
-      else {
-        tmpGeneral = deviceJson.general.v2
-      }
-      copy.lastUpdate = tmpGeneral.lastUpdate
-      copy.lastCommTime = tmpGeneral.lastCommTime
-      copy.nextExpectedWakeup = tmpGeneral.nextExpectedWakeup
-      copy.deviceType = tmpGeneral.deviceType
-      copy.adapterType = tmpGeneral.adapterType
-      copy.zid = tmpGeneral.zid
-      copy.roomId = tmpGeneral.roomId
-      copy.serialNumber = tmpGeneral.serialNumber
-      copy.fingerprint = tmpGeneral.fingerprint
-      copy.manufacturerName = tmpGeneral.manufacturerName
-      copy.tamperStatus = tmpGeneral.tamperStatus
-      copy.name = tmpGeneral.name
-      copy.acStatus = tmpGeneral.acStatus
-      copy.batteryLevel = tmpGeneral.batteryLevel
-      copy.batteryStatus = tmpGeneral.batteryStatus
+
       if (tmpGeneral.componentDevices) {
-        copy.componentDevices = tmpGeneral.componentDevices
+        curDeviceInfo.componentDevices = tmpGeneral.componentDevices
       }
     }
-    if (deviceJson.context || deviceJson.adapter) {
-      def tmpAdapter
-      if (deviceJson.context?.v1?.adapter?.v1) {
-        tmpAdapter = deviceJson.context.v1.adapter.v1
-      }
-      else if (deviceJson.adapter?.v1) {
-        tmpAdapter = deviceJson.adapter?.v1
-      }
+    if (deviceJson?.context || deviceJson?.adapter) {
+      def tmpAdapter = deviceJson.context?.v1?.adapter?.v1 ?: deviceJson.adapter?.v1
 
-      copy.signalStrength = tmpAdapter?.signalStrength
-      copy.firmware = tmpAdapter?.firmwareVersion
-      if (tmpAdapter?.fingerprint?.firmware?.version)
-        copy.firmware = "${tmpAdapter?.fingerprint?.firmware?.version}.${tmpAdapter?.fingerprint?.firmware?.subversion}"
-      copy.hardwareVersion = tmpAdapter?.fingerprint?.hardwareVersion.toString()
+      curDeviceInfo.signalStrength = tmpAdapter?.signalStrength
+      curDeviceInfo.firmware = tmpAdapter?.firmwareVersion
+      if (tmpAdapter?.fingerprint?.firmware?.version) {
+        curDeviceInfo.firmware = "${tmpAdapter.fingerprint.firmware.version}.${tmpAdapter.fingerprint.firmware?.subversion}"
+        curDeviceInfo.hardwareVersion = tmpAdapter.fingerprint?.hardwareVersion?.toString()
+      }
 
       def tmpContext = deviceJson.context?.v1
-      copy.deviceName = tmpContext?.deviceName
-      copy.roomName = tmpContext?.roomName
-      if (copy.batteryStatus == null && tmpContext.batteryStatus != null)
-        copy.batteryStatus = tmpContext.batteryStatus
-      if ("alarm.smoke" == copy.deviceType && tmpContext?.device?.v1?.alarmStatus) {
-        copy.state = jsonSlurper.parseText('{"smoke": "" }')
-        copy.state.smoke = tmpContext.device.v1
+      curDeviceInfo.deviceName = tmpContext?.deviceName
+      curDeviceInfo.roomName = tmpContext?.roomName
+      if (curDeviceInfo.batteryStatus == null && tmpContext.batteryStatus != null) {
+        curDeviceInfo.batteryStatus = tmpContext.batteryStatus
+      }
+      if (curDeviceInfo.deviceType == "alarm.smoke" && tmpContext?.device?.v1?.alarmStatus) {
+        curDeviceInfo.state = [smoke: tmpContext.device.v1]
       }
     }
-    if (deviceJson.impulse) {
-      def tmpImpulse
-      if (deviceJson.impulse?.v1[0]) {
-        tmpImpulse = deviceJson.impulse?.v1[0]
-      }
-      copy.impulseType = tmpImpulse.impulseType
+    if (deviceJson?.impulse) {
+      def tmpImpulse = deviceJson.impulse?.v1[0]
 
-      copy.impulses = deviceJson.impulse.v1.collectEntries {
+      curDeviceInfo.impulseType = tmpImpulse.impulseType
+
+      curDeviceInfo.impulses = deviceJson.impulse.v1.collectEntries {
         [(it.impulseType): it.data]
       }
 
     }
 
-    //if (deviceJson.adapter) {
-    //  copy.signalStrength = [deviceJson.adapter.v1]
-    //}
-
-    if (deviceJson.device) {
+    if (deviceJson?.device) {
       tmpDevice
       //logTrace "what has this device? ${tmpDevice}"
       if (deviceJson.device.v1) {
-        copy.state = deviceJson.device.v1
-        //copy.faulted = tmpDevice.faulted
-        //copy.mode = tmpDevice.mode
+        curDeviceInfo.state = deviceJson.device.v1
+        //curDeviceInfo.faulted = tmpDevice.faulted
+        //curDeviceInfo.mode = tmpDevice.mode
       }
 
     }
 
     //likely a passthru
-    if (deviceJson.data) {
-      assert returnResult.msg == 'Passthru'
-      copy.state = deviceJson.data
-      copy.zid = copy.assetId
-      copy.deviceType = deviceJson.type
+    if (deviceJson?.data) {
+      assert curDeviceInfo.msg == 'Passthru'
+      curDeviceInfo.state = deviceJson.data
+      curDeviceInfo.zid = curDeviceInfo.assetId
+      curDeviceInfo.deviceType = deviceJson.type
     }
 
-    deviceInfos << copy
+    deviceInfos << curDeviceInfo
 
-    //if (copy.deviceType == "range-extender.zwave") {
+    //if (curDeviceInfo.deviceType == "range-extender.zwave") {
     //  log.warn "range-extender.zwave message: ${JsonOutput.prettyPrint(JsonOutput.toJson(deviceJson))}"
     //}
-    if (copy.deviceType == null) {
+    if (curDeviceInfo.deviceType == null) {
       log.warn "null device type message?: ${JsonOutput.prettyPrint(JsonOutput.toJson(deviceJson))}"
     }
-
   }
 
   logTrace "found ${deviceInfos.size()} devices"
@@ -761,10 +726,7 @@ def createDevice(deviceInfo) {
   logTrace "deviceInfo: ${deviceInfo}"
 
   //quick check
-  if (deviceInfo == null
-    || deviceInfo.deviceType == null
-    || DEVICE_TYPES[deviceInfo.deviceType] == null
-    || DEVICE_TYPES[deviceInfo.deviceType].hidden) {
+  if (deviceInfo?.deviceType == null || DEVICE_TYPES.get(deviceInfo.deviceType)?.hidden) {
     logDebug "Not a creatable device. ${deviceInfo.deviceType}"
     return
   }

--- a/src/drivers/ring-virtual-alarm-hub.groovy
+++ b/src/drivers/ring-virtual-alarm-hub.groovy
@@ -21,10 +21,9 @@
  *              Added fireAlarm attribute to hold fire alarm status
  *  2020-02-29: Changed namespace
  *  2020-05-16: Fixed base station brightness command
- *
+ *  2021-08-16: Remove unnecessary safe object traversal
  */
 
-import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
 metadata {
@@ -34,14 +33,19 @@ metadata {
     capability "Audio Volume"
     capability "Alarm"
     capability "Refresh"
+    capability "PowerSource"
 
-    attribute "mode", "string"
-    attribute "entryDelay", "string"
-    attribute "exitDelay", "string"
-    attribute "fireAlarm", "string"
+    attribute "acStatus", "string"
+    attribute "batteryBackup", "string"
     attribute "brightness", "number"
     attribute "countdownTimeLeft", "number"
     attribute "countdownTotal", "number"
+    attribute "cellular", "string"
+    attribute "entryDelay", "string"
+    attribute "exitDelay", "string"
+    attribute "fireAlarm", "string"
+    attribute "mode", "string"
+    attribute "wifi", "string"
 
     command "setBrightness", [[name: "Set LED Brightness*", type: "NUMBER", range: "0..100", description: "Choose a value between 0 and 100"]]
     command "setMode", [[name: "Set Mode*", type: "ENUM", description: "Set the Ring Alarm's mode", constraints: ["Disarmed", "Home", "Away"]]]
@@ -238,14 +242,14 @@ def setValues(deviceInfo) {
       checkChanged("exitDelay", "inactive")
     }
   }
-  if (deviceInfo.state?.mode && syncRingToHsm && location.hsmStatus != RING_TO_HSM_MODE_MAP[MODES["${deviceInfo.state?.mode}"]].status) {
-    def hsmMode = RING_TO_HSM_MODE_MAP[MODES["${deviceInfo.state?.mode}"]].set
+  if (deviceInfo.state?.mode && syncRingToHsm && location.hsmStatus != RING_TO_HSM_MODE_MAP[MODES["${deviceInfo.state.mode}"]].status) {
+    def hsmMode = RING_TO_HSM_MODE_MAP[MODES["${deviceInfo.state.mode}"]].set
     logInfo "Setting HSM to ${hsmMode}"
-    logTrace "mode: ${MODES["${deviceInfo.state?.mode}"]} hsmStatus: ${location.hsmStatus}"
+    logTrace "mode: ${MODES["${deviceInfo.state.mode}"]} hsmStatus: ${location.hsmStatus}"
     sendLocationEvent(name: "hsmSetArm", value: hsmMode)
   }
-  if (deviceInfo.state?.siren && device.currentValue("alarm") != deviceInfo.state?.siren.state) {
-    def alarm = deviceInfo.state?.siren.state == "on" ? "siren" : "off"
+  if (deviceInfo.state?.siren && device.currentValue("alarm") != deviceInfo.state.siren.state) {
+    def alarm = deviceInfo.state.siren.state == "on" ? "siren" : "off"
     sendEvent(name: "alarm", value: alarm)
     if (alarm != "off") {
       sendEvent(name: "countdownTimeLeft", value: 0)
@@ -254,16 +258,14 @@ def setValues(deviceInfo) {
     }
   }
   if (deviceInfo.state?.alarmInfo) {
-    def entryDelay = deviceInfo.state?.alarmInfo.state == "entry-delay" ? "active" : "inactive"
-    checkChanged("entryDelay", entryDelay)
+    checkChanged("entryDelay", deviceInfo.state.alarmInfo.state == "entry-delay" ? "active" : "inactive")
 
     //TODO: after a small cooking mishap noticed that fire-alarm has a different alarmInfo.state than intrusion so I added an attribute and a
     //case for it while I decide what to do with it long term.  should this also set the "alarm" attribute or should the base also implement
     //smoke alarm? or neither and it's just fine in the attribute since there will be a device for the smoke detector?  in fact, do I just
     //ignore this update because the smoke detector device will already get its own update?  or does it?
 
-    def fireAlarm = deviceInfo.state?.alarmInfo.state == "fire-alarm" ? "active" : "inactive"
-    checkChanged("fireAlarm", fireAlarm)
+    checkChanged("fireAlarm", deviceInfo.state.alarmInfo.state == "fire-alarm" ? "active" : "inactive")
 
     //TODO: work on faulted devices
     //state.faultedDevices.each {
@@ -272,8 +274,7 @@ def setValues(deviceInfo) {
     //}.collect()
   }
   if (deviceInfo.state?.transition) {
-    def exitDelay = deviceInfo.state?.transition == "exit" ? "active" : "inactive"
-    checkChanged("exitDelay", exitDelay)
+    checkChanged("exitDelay", deviceInfo.state.transition == "exit" ? "active" : "inactive")
     sendEvent(name: "countdownTimeLeft", value: deviceInfo.state?.timeLeft)
     sendEvent(name: "countdownTotal", value: deviceInfo.state?.total)
   }
@@ -282,64 +283,84 @@ def setValues(deviceInfo) {
     checkChanged("exitDelay", exitDelay)
   }
   if (deviceInfo.state?.percent) {
-    log.warn "${device.label} is updating firmware: ${deviceInfo.state?.percent}% complete"
+    log.warn "${device.label} is updating firmware: ${deviceInfo.state.percent}% complete"
   }
   if (cancelAlertsOnDisarm && MODES["${deviceInfo.state?.mode}"] == "off") {
     sendLocationEvent(name: "hsmSetArm", value: "cancelAlerts")
   }
-  if (deviceInfo.state?.volume != null) {
-    checkChanged("volume", (deviceInfo.state.volume * 100) as Integer)
+  if (deviceInfo?.acStatus != null) {
+    def acStatus = deviceInfo.acStatus
+    checkChanged("acStatus", acStatus == "ok" ? "connected" : (acStatus == "error" ? "disconnected" : "brownout"))
+    checkChanged("powerSource", acStatus == "ok" ? "mains" : (acStatus == "error" ? "battery" : "unknown"))
   }
-  if (deviceInfo.batteryLevel != null) {
-    checkChanged("battery", deviceInfo.batteryLevel)
+  
+  for(key in ['brightness', 'volume']) {
+    if (deviceInfo?.state?.get(key) != null) {
+      checkChanged(key, (deviceInfo.state[key] * 100) as Integer)
+    }
   }
-  if (deviceInfo.state?.brightness != null) {
-    checkChanged("brightness", (deviceInfo.state.brightness * 100) as Integer)
-  }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-  }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
-  }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
-  }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
+    }
+  }  
+  
   if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
     device.updateDataValue("firmware", deviceInfo.firmware)
   }
-  if (deviceInfo.state?.version && deviceInfo.state?.version?.softwareVersion
-    && device.getDataValue("softwareVersion") != deviceInfo.state?.version?.softwareVersion) {
-    device.updateDataValue("softwareVersion", deviceInfo.state?.version?.softwareVersion)
+  if (deviceInfo.state?.version?.softwareVersion
+    && device.getDataValue("softwareVersion") != deviceInfo.state.version.softwareVersion) {
+    device.updateDataValue("softwareVersion", deviceInfo.state.version.softwareVersion)
   }
   if (deviceInfo.state?.networks) {
-    def nw = deviceInfo.state?.networks
-    if (nw.ppp0) {
-      sendEvent(name: nw.ppp0.type.capitalize(), value: "${nw.ppp0.name} RSSI ${nw.ppp0.rssi}")
+    def nw = deviceInfo.state.networks
+
+    if (nw.ppp0 != null) {
+      if (nw.ppp0?.type) {
+        device.updateDataValue("ppp0Type", nw.ppp0.type.capitalize())
+      }
+      if (nw.ppp0?.name) {
+        device.updateDataValue("ppp0Name", nw.ppp0.name)
+      }
+      if (nw.ppp0?.rssi) {
+        device.updateDataValue("ppp0Rssi", nw.ppp0.rssi.toString())
+      }
+
+      def type = device.getDataValue("ppp0Type")
+      def name = device.getDataValue("ppp0Name")
+      def rssi = device.getDataValue("ppp0Rssi")
+
+      logInfo "ppp0 ${type} ${name} RSSI ${RSSI}"
+      checkChanged('cellular', "${name} RSSI ${rssi}")
+      state.ppp0 = "${name} RSSI ${rssi}"
     }
-    if (nw.wlan0.type != null) {
-      sendEvent(name: nw.wlan0.type.capitalize(), value: "${nw.wlan0.ssid} RSSI ${nw.wlan0.rssi}")
+    if (nw.wlan0 != null) {
+      if (nw.wlan0?.type) {
+        device.updateDataValue("wlan0Type", nw.wlan0.type.capitalize())
+      }
+      if (nw.wlan0?.ssid) {
+        device.updateDataValue("wlan0Ssid", nw.wlan0.ssid)
+      }
+      if (nw.wlan0?.rssi) {
+        device.updateDataValue("wlan0Rssi", nw.wlan0.rssi.toString())
+      }
+      
+      def type = device.getDataValue("wlan0Type")
+      def ssid = device.getDataValue("wlan0Ssid")
+      def rssi = device.getDataValue("wlan0Rssi")
+
+      logInfo "wlan0 ${type} ${ssid} RSSI ${RSSI}"
+      checkChanged('wifi', "${ssid} RSSI ${rssi}")
+      state.wlan0 = "${ssid} RSSI ${rssi}"
     }
   }
   if (deviceInfo.state?.batteryBackup) {
-    sendEvent(name: "batteryBackup", value: deviceInfo.state?.batteryBackup)
+    sendEvent(name: "batteryBackup", value: deviceInfo.state.batteryBackup)
   }
 }
 
-def checkChanged(attribute, newStatus) {
-  if (device.currentValue(attribute) != newStatus) {
-    logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
-    sendEvent(name: attribute, value: newStatus)
-  }
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)
@@ -347,17 +368,10 @@ def checkChanged(attribute, newStatus, unit) {
 }
 
 def saveImportantInfo(deviceInfo) {
-  if (deviceInfo.deviceType == "security-panel" && device.getDataValue("security-panel-zid") != deviceInfo.zid) {
-    device.updateDataValue("security-panel-zid", deviceInfo.zid)
-  }
-  if (deviceInfo.deviceType == "adapter.zwave" && device.getDataValue("adapter.zwave-zid") != deviceInfo.zid) {
-    device.updateDataValue("adapter.zwave-zid", deviceInfo.zid)
-  }
-  if (deviceInfo.deviceType == "hub.redsky" && device.getDataValue("hub.redsky-zid") != deviceInfo.zid) {
-    device.updateDataValue("hub.redsky-zid", deviceInfo.zid)
-  }
-  if (deviceInfo.deviceType == "access-code.vault" && device.getDataValue("access-code.vault-zid") != deviceInfo.zid) {
-    device.updateDataValue("access-code.vault-zid", deviceInfo.zid)
+  for(deviceType in ['access-code.vault', 'adapter.zwave', 'hub.redsky', 'security-panel']) {
+    if (deviceInfo.deviceType == deviceType && device.getDataValue("${deviceType}-zid") != deviceInfo.zid) {
+      device.updateDataValue("${deviceType}-zid", deviceInfo.zid)
+    }
   }
 }
 

--- a/src/drivers/ring-virtual-beams-light.groovy
+++ b/src/drivers/ring-virtual-beams-light.groovy
@@ -23,11 +23,9 @@
  *              Fixed an issue where hardware version was lost
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
 
-import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
 metadata {
@@ -97,41 +95,31 @@ def setValues(deviceInfo) {
   logDebug "updateDevice(deviceInfo)"
   logTrace "deviceInfo: ${JsonOutput.prettyPrint(JsonOutput.toJson(deviceInfo))}"
 
-  if (deviceInfo.state && deviceInfo.state.motionStatus != null) {
-    def motion = deviceInfo.state.motionStatus == "clear" ? "inactive" : "active"
-    checkChanged("motion", motion)
+  if (deviceInfo?.state?.motionStatus != null) {
+    checkChanged("motion", deviceInfo.state.motionStatus == "clear" ? "inactive" : "active")
   }
-  if (deviceInfo.state && deviceInfo.state.on != null) {
-    def switchState = deviceInfo.state.on ? "on" : "off"
-    checkChanged("switch", switchState)
+  if (deviceInfo?.state?.on != null) {
+    checkChanged("switch", deviceInfo.state.on ? "on" : "off")
   }
-  if (deviceInfo.state && deviceInfo.state.level != null && !NO_BRIGHTNESS_DEVICES.contains(device.getDataValue("fingerprint"))) {
-    def brightness = (deviceInfo.state.level.toDouble() * 100).toInteger()
-    checkChanged("brightness", brightness)
+  if (deviceInfo?.state?.level != null && !NO_BRIGHTNESS_DEVICES.contains(device.getDataValue("fingerprint"))) {
+    checkChanged("brightness", (deviceInfo.state.level.toDouble() * 100).toInteger())
   }
   if (deviceInfo.batteryLevel != null && !discardBatteryLevel && !NO_BATTERY_DEVICES.contains(device.getDataValue("fingerprint"))) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
   if (deviceInfo.lastUpdate != state.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
     sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
+    }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
-  }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
-  }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
+
   if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
     device.updateDataValue("firmware", deviceInfo.firmware)
   }
@@ -153,11 +141,7 @@ def getNO_BRIGHTNESS_DEVICES() {
   ]
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-camera-with-siren.groovy
+++ b/src/drivers/ring-virtual-camera-with-siren.groovy
@@ -20,10 +20,7 @@
  *  2019-12-20: Started tinkering with getting thumbnails
  *  2020-02-29: Changed namespace
  *  2020-05-19: Snapshot preference
- *
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Camera with Siren", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -196,9 +193,9 @@ def motionOff(data) {
   childParse("dings", [msg: null])
 }
 
-def checkChanged(attribute, newStatus) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
-    sendEvent(name: attribute, value: newStatus)
+    sendEvent(name: attribute, value: newStatus, unit: unit)
   }
 }

--- a/src/drivers/ring-virtual-camera.groovy
+++ b/src/drivers/ring-virtual-camera.groovy
@@ -20,10 +20,7 @@
  *  2019-11-18: Differentiated between ring and motion events
  *  2020-02-29: Changed namespace
  *  2020-05-19: Snapshot preference
- *
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Camera", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -139,9 +136,9 @@ def motionOff(data) {
   childParse("dings", [msg: null])
 }
 
-def checkChanged(attribute, newStatus) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
-    sendEvent(name: attribute, value: newStatus)
+    sendEvent(name: attribute, value: newStatus, unit: unit)
   }
 }

--- a/src/drivers/ring-virtual-chime.groovy
+++ b/src/drivers/ring-virtual-chime.groovy
@@ -18,10 +18,7 @@
  *  2019-11-15: Import URL
  *  2019-12-20: API changes to accommodate Ring upstream API changes
  *  2020-02-29: Changed namespace
- *
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Chime", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",

--- a/src/drivers/ring-virtual-contact-sensor.groovy
+++ b/src/drivers/ring-virtual-contact-sensor.groovy
@@ -19,10 +19,8 @@
  *  2020-02-12: Fixed battery % to show correctly in dashboards
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Contact Sensor", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -64,49 +62,34 @@ def setValues(deviceInfo) {
   logDebug "updateDevice(deviceInfo)"
   logTrace "deviceInfo: ${deviceInfo}"
 
-  if (deviceInfo.state && deviceInfo.state.faulted != null) {
-    def contact = deviceInfo.state.faulted ? "open" : "closed"
-    checkChanged("contact", contact)
+  if (deviceInfo?.state?.faulted != null) {
+    checkChanged("contact", deviceInfo.state.faulted ? "open" : "closed")
   }
   if (deviceInfo.batteryLevel != null) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-flood-freeze-sensor.groovy
+++ b/src/drivers/ring-virtual-flood-freeze-sensor.groovy
@@ -17,10 +17,8 @@
  *  2020-02-11: Initial
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Alarm Flood & Freeze Sensor", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -63,55 +61,39 @@ def setValues(deviceInfo) {
   logDebug "updateDevice(deviceInfo)"
   logTrace "deviceInfo: ${deviceInfo}"
 
-  if (deviceInfo.state && deviceInfo.state.faulted != null) {
+  if (deviceInfo?.state?.faulted != null) {
     if (deviceInfo.state.flood?.faulted != null) {
-      def water = deviceInfo.state.flood.faulted ? "wet" : "dry"
-      checkChanged("water", water)
+      checkChanged("water", deviceInfo.state.flood.faulted ? "wet" : "dry")
     }
     if (deviceInfo.state.freeze?.faulted != null) {
-      def freeze = deviceInfo.state.freeze.faulted ? "detected" : "clear"
-      checkChanged("freeze", freeze)
+      checkChanged("freeze", deviceInfo.state.freeze.faulted ? "detected" : "clear")
     }
   }
   if (deviceInfo.batteryLevel != null) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-light-with-siren.groovy
+++ b/src/drivers/ring-virtual-light-with-siren.groovy
@@ -18,10 +18,8 @@
  *  2019-11-15: Import URL
  *  2020-02-29: Changed namespace
  *  2020-05-19: Snapshot preference
- *
  */
 
-import groovy.json.JsonSlurper
 import groovy.transform.Field
 
 metadata {
@@ -284,10 +282,10 @@ def motionOff(data) {
   childParse("dings", [msg: null])
 }
 
-def checkChanged(attribute, newStatus) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
-    sendEvent(name: attribute, value: newStatus)
+    sendEvent(name: attribute, value: newStatus, unit: unit)
   }
 }
 

--- a/src/drivers/ring-virtual-light.groovy
+++ b/src/drivers/ring-virtual-light.groovy
@@ -22,10 +22,8 @@
  *  2020-02-11: Added second battery support
  *  2020-02-29: Changed namespace
  *  2020-05-19: Snapshot preference
- *
  */
 
-import groovy.json.JsonSlurper
 import groovy.transform.Field
 
 metadata {
@@ -271,11 +269,7 @@ def motionOff(data) {
   childParse("dings", [msg: null])
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-lock.groovy
+++ b/src/drivers/ring-virtual-lock.groovy
@@ -19,10 +19,8 @@
  *  2020-02-12: Fixed battery % to show correctly in dashboards
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Lock", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -74,44 +72,31 @@ def setValues(deviceInfo) {
   logDebug "updateDevice(deviceInfo)"
   logTrace "deviceInfo: ${deviceInfo}"
 
-  if (deviceInfo.state && deviceInfo.state.locked != null) {
+  if (deviceInfo?.state?.locked != null) {
     checkChanged("lock", deviceInfo.state.locked)
   }
   if (deviceInfo.batteryLevel != null) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-motion-sensor.groovy
+++ b/src/drivers/ring-virtual-motion-sensor.groovy
@@ -19,10 +19,8 @@
  *  2020-02-12: Fixed battery % to show correctly in dashboards
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Motion Sensor", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -64,49 +62,34 @@ def setValues(deviceInfo) {
   logDebug "updateDevice(deviceInfo)"
   logTrace "deviceInfo: ${deviceInfo}"
 
-  if (deviceInfo.state && deviceInfo.state.faulted != null) {
-    def motion = deviceInfo.state.faulted ? "active" : "inactive"
-    checkChanged("motion", motion)
+  if (deviceInfo?.state?.faulted != null) {
+    checkChanged("motion", deviceInfo.state.faulted ? "active" : "inactive")
   }
   if (deviceInfo.batteryLevel != null) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.lastCommTime = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-panic-button.groovy
+++ b/src/drivers/ring-virtual-panic-button.groovy
@@ -1,0 +1,100 @@
+/**
+ *  Ring Virtual Panic Button Driver
+ *
+ *  Copyright 2019 Ben Rimmasch
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *
+ *  Change Log:
+ *  2020-08-16: Initial
+ */
+
+metadata {
+  definition(name: "Ring Virtual Panic Button", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
+    importUrl: "https://raw.githubusercontent.com/codahq/ring_hubitat_codahq/master/src/drivers/ring-virtual-panic-button.groovy") {
+    capability "Refresh"
+    capability "Battery"
+    capability "TamperAlert"
+
+    attribute "lastCheckin", "string"
+  }
+
+  preferences {
+    input name: "descriptionTextEnable", type: "bool", title: "Enable descriptionText logging", defaultValue: false
+    input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: false
+    input name: "traceLogEnable", type: "bool", title: "Enable trace logging", defaultValue: false
+  }
+}
+
+private logInfo(msg) {
+  if (descriptionTextEnable) log.info msg
+}
+
+def logDebug(msg) {
+  if (logEnable) log.debug msg
+}
+
+def logTrace(msg) {
+  if (traceLogEnable) log.trace msg
+}
+
+def refresh() {
+  logDebug "Attempting to refresh."
+  //parent.simpleRequest("refresh-device", [dni: device.deviceNetworkId])
+}
+
+def setValues(deviceInfo) {
+  logDebug "updateDevice(deviceInfo)"
+  logTrace "deviceInfo: ${deviceInfo}"
+
+  if (deviceInfo.state && deviceInfo.state.testMode != null) {
+    checkChanged("testMode", deviceInfo.state.testMode)
+  }
+  if (deviceInfo.batteryLevel != null) {
+    checkChanged("battery", deviceInfo.batteryLevel, "%")
+  }
+  if (deviceInfo.tamperStatus) {
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
+  }
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
+    }
+  }
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+  }
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
+  }
+}
+
+def checkChanged(attribute, newStatus, unit=null) {
+  if (device.currentValue(attribute) != newStatus) {
+    logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
+    sendEvent(name: attribute, value: newStatus, unit: unit)
+  }
+}
+
+private convertToLocalTimeString(dt) {
+  def timeZoneId = location?.timeZone?.ID
+  if (timeZoneId) {
+    return dt.format("yyyy-MM-dd h:mm:ss a", TimeZone.getTimeZone(timeZoneId))
+  }
+  else {
+    return "$dt"
+  }
+}

--- a/src/drivers/ring-virtual-retrofit-alarm-kit.groovy
+++ b/src/drivers/ring-virtual-retrofit-alarm-kit.groovy
@@ -15,10 +15,9 @@
  *
  *  Change Log:
  *  2020-02-29: Initial
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
 
-import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
 metadata {
@@ -67,40 +66,27 @@ def setValues(deviceInfo) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.lastCommTime = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
-  }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-siren.groovy
+++ b/src/drivers/ring-virtual-siren.groovy
@@ -19,10 +19,8 @@
  *  2020-02-12: Fixed battery % to show correctly in dashboards
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Siren", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -84,41 +82,27 @@ def setValues(deviceInfo) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-smoke-alarm.groovy
+++ b/src/drivers/ring-virtual-smoke-alarm.groovy
@@ -19,10 +19,8 @@
  *              Made some guesses on how the alarm component of this actually works
  *  2020-02-29: Added checkin event
  *              Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Smoke Alarm", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -65,16 +63,16 @@ def setValues(deviceInfo) {
   logTrace "deviceInfo: ${deviceInfo}"
 
   /* this block possibly unecessary*/
-  if (deviceInfo.state && deviceInfo.state.smoke != null) {
-    def smoke = (deviceInfo.state.smoke.alarmStatus == "active") ? "detected" : (deviceInfo.state.smoke.alarmStatus == "inactive" ? "clear" : "tested")
-    checkChanged("smoke", smoke)
+  if (deviceInfo?.state?.smoke != null) {
+    def alarmStatus = deviceInfo.state.smoke.alarmStatus
+    checkChanged("smoke", alarmStatus == "active" ? "detected" : (alarmStatus == "inactive" ? "clear" : "tested"))
     if (deviceInfo.state.smoke.enabledTimeMs)
       state.smokeEnabled = deviceInfo.state.smoke.enabledTimeMs
   }
   /* end block */
-  if (deviceInfo.state && deviceInfo.state.alarmStatus != null) {
-    def smoke = (deviceInfo.state.alarmStatus == "active") ? "detected" : (deviceInfo.state.alarmStatus == "inactive" ? "clear" : "tested")
-    checkChanged("smoke", smoke)
+  if (deviceInfo?.state?.alarmStatus != null) {
+    def alarmStatus = deviceInfo.state.alarmStatus
+    checkChanged("smoke", alarmStatus == "active" ? "detected" : (alarmStatus == "inactive" ? "clear" : "tested"))
     if (deviceInfo.state.enabledTimeMs)
       state.smokeEnabled = deviceInfo.state.enabledTimeMs
   }
@@ -82,41 +80,27 @@ def setValues(deviceInfo) {
     checkChanged("battery", deviceInfo.batteryLevel, "%")
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-    if (deviceInfo.impulseType == "comm.heartbeat") {
-      sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
+  
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
     }
   }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
+  
+  if (deviceInfo?.impulseType == "comm.heartbeat") {
+    sendEvent(name: "lastCheckin", value: convertToLocalTimeString(new Date()), displayed: false, isStateChange: true)
   }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
   }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
-  }
-
 }
 
-def checkChanged(attribute, newStatus) {
-  checkChanged(attribute, newStatus, null)
-}
-
-def checkChanged(attribute, newStatus, unit) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
     sendEvent(name: attribute, value: newStatus, unit: unit)

--- a/src/drivers/ring-virtual-switch.groovy
+++ b/src/drivers/ring-virtual-switch.groovy
@@ -17,10 +17,8 @@
  *  2019-11-12: Initial
  *  2019-11-15: Import URL
  *  2020-02-29: Changed namespace
- *
+ *  2021-08-16: Reduce repetition in some of the code
  */
-
-import groovy.json.JsonSlurper
 
 metadata {
   definition(name: "Ring Virtual Switch", namespace: "ring-hubitat-codahq", author: "Ben Rimmasch",
@@ -76,36 +74,25 @@ def setValues(deviceInfo) {
     checkChanged("battery", deviceInfo.batteryLevel)
   }
   if (deviceInfo.tamperStatus) {
-    def tamper = deviceInfo.tamperStatus == "tamper" ? "detected" : "clear"
-    checkChanged("tamper", tamper)
-  }
-  if (deviceInfo.lastUpdate) {
-    state.lastUpdate = deviceInfo.lastUpdate
-  }
-  if (deviceInfo.impulseType) {
-    state.impulseType = deviceInfo.impulseType
-  }
-  if (deviceInfo.lastCommTime) {
-    state.signalStrength = deviceInfo.lastCommTime
-  }
-  if (deviceInfo.nextExpectedWakeup) {
-    state.nextExpectedWakeup = deviceInfo.nextExpectedWakeup
-  }
-  if (deviceInfo.signalStrength) {
-    state.signalStrength = deviceInfo.signalStrength
-  }
-  if (deviceInfo.firmware && device.getDataValue("firmware") != deviceInfo.firmware) {
-    device.updateDataValue("firmware", deviceInfo.firmware)
-  }
-  if (deviceInfo.hardwareVersion && device.getDataValue("hardwareVersion") != deviceInfo.hardwareVersion) {
-    device.updateDataValue("hardwareVersion", deviceInfo.hardwareVersion)
+    checkChanged("tamper", deviceInfo.tamperStatus == "tamper" ? "detected" : "clear")
   }
 
+  for(key in ['impulseType', 'lastCommTime', 'lastUpdate', 'nextExpectedWakeup', 'signalStrength']) {
+    if (deviceInfo[key]) {
+      state[key] = deviceInfo[key]
+    }
+  }
+  
+  for(key in ['firmware', 'hardwareVersion']) {
+    if (deviceInfo[key] && device.getDataValue(key) != deviceInfo[key]) {
+      device.updateDataValue(key, deviceInfo[key])
+    }
+  }
 }
 
-def checkChanged(attribute, newStatus) {
+def checkChanged(attribute, newStatus, unit=null) {
   if (device.currentValue(attribute) != newStatus) {
     logInfo "${attribute.capitalize()} for device ${device.label} is ${newStatus}"
-    sendEvent(name: attribute, value: newStatus)
+    sendEvent(name: attribute, value: newStatus, unit: unit)
   }
 }


### PR DESCRIPTION
This should improve how reliable the watchdog checking is. I've had many times where the websocket would be disconnected, but the watchdog would not catch it. I updated the watchdog so that it is based on the last time that a msg was received from the websocket, rather than the last time that 'refresh()` was called

I've been using this code for 3-4 months and the new watchdog code has reliably recovered the websocket connection many times.