### PR TITLE
Adding Ring Alarm Pro Support - PLEASE CODE REVIEW

### DIFF
--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -613,7 +613,7 @@ private discoverDevices() {
   def supportedIds = getDeviceIds()
   logTrace "supportedIds ${supportedIds}"
   state.devices = supportedIds
-  def alarmCapable = (state.devices.find { it.kind == "base_station_v1" }?.size() ?: 0) > 0
+  def alarmCapable = (state.devices.find { it.kind =~ /base_station_v/ }?.size() ?: 0) > 0
   getAPIDevice().setState("alarmCapable", alarmCapable, "bool-set")
 }
 


### PR DESCRIPTION
Adding Ring Alarm Pro Support. I switched to a regular expression to capture any form of "base_station_v*" given the two known alarm bases are "v1" and "vk". Open to a better/safer approach here, or if I'm misunderstanding how regular expressions work in Groovy.