### PR TITLE
Adding Support for Alarm Hub Pro

### DIFF
--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -613,7 +613,7 @@ private discoverDevices() {
   def supportedIds = getDeviceIds()
   logTrace "supportedIds ${supportedIds}"
   state.devices = supportedIds
-  def alarmCapable = (state.devices.find { it.kind == "base_station_v1" }?.size() ?: 0) > 0
+  def alarmCapable = (state.devices.find { it.kind =~ /base_station_v1|base_station_k1/ }?.size() ?: 0) > 0
   getAPIDevice().setState("alarmCapable", alarmCapable, "bool-set")
 }
 


### PR DESCRIPTION
The new Alarm Hub pro identifies itself as base_station_v1.
This change looks explicitly for base_station_v1 or base_station_vk to set "alarmCapable" to true. Today only _v1 will set it to true.