### PR TITLE
Fix for glassbreak sensor crashing api

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Hubitat Ring Integration (Unofficial)",
   "author": "codahq",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "betaVersion": "0.5.0.15",
   "minimumHEVersion": "0.0",
   "dateReleased": "2022-01-20",
-  "releaseNotes": "Add support for Ring Video Doorbell 4 (Oyster) and Ring Video Doorbell Wired (Graham Cracker)",
+  "releaseNotes": "Add support for Ring Video Doorbell 4 (Oyster) and Ring Video Doorbell Wired (Graham Cracker); fixes bug when parsing glassbreak sensors from Ring API",
   "apps": [
     {
       "id": "981fa0e5-b7c7-4459-a9ba-7ccdc51faa55",


### PR DESCRIPTION
The glass break sensors cause the API to crash while creating child devices, because the device type lookup returns null, resulting a NullPointerException.  The NPE is caught by the catch block, however, in the catch block that same lookup occurs again, resulting in a new NPE which is not handled, and this in turn aborts the add child devices call before all devices are added.

Since glass break sensors are only in the develop branch (even though they are being published in HPM on the production branch), this is a work-around to clean up the device type handling and enable those of us w/o the beta branches to use the supported device even though our systems have glass break sensor installed.