### PR TITLE
check msg.sidewalk_connection for Sidewalk warning

### DIFF
--- a/src/drivers/ring-virtual-camera-with-siren.groovy
+++ b/src/drivers/ring-virtual-camera-with-siren.groovy
@@ -159,6 +159,10 @@ void handleRefresh(final Map msg) {
       checkChanged("rssi", health.rssi)
     }
   }
+
+  if (msg.is_sidewalk_gateway && msg.sidewalk_connection) {
+    log.warn("Your device is being used as an Amazon sidewalk device.")
+  }
 }
 
 void motionOff() {

--- a/src/drivers/ring-virtual-camera.groovy
+++ b/src/drivers/ring-virtual-camera.groovy
@@ -128,6 +128,10 @@ void handleRefresh(final Map msg) {
       checkChanged("rssi", health.rssi)
     }
   }
+
+  if (msg.is_sidewalk_gateway && msg.sidewalk_connection) {
+    log.warn("Your device is being used as an Amazon sidewalk device.")
+  }
 }
 
 void motionOff() {

--- a/src/drivers/ring-virtual-light-with-siren.groovy
+++ b/src/drivers/ring-virtual-light-with-siren.groovy
@@ -214,7 +214,7 @@ void handleRefresh(final Map msg) {
     }
   }
 
-  if (msg.is_sidewalk_gateway) {
+  if (msg.is_sidewalk_gateway && msg.sidewalk_connection) {
     log.warn("Your device is being used as an Amazon sidewalk device.")
   }
 


### PR DESCRIPTION
Per Ring technical support, the `is_sidewalk_gateway` parameter in the API response indicates only whether a device is capable of being used as a Sidewalk gateway. The `sidewalk_connection` parameter indicates whether Sidewalk is enabled in the Ring account. Both of these must be true for any device to be actively being used as a Sidewalk gateway.