### PR TITLE
Fixed dingable device detection

### DIFF
--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -614,7 +614,7 @@ def uninstalled() {
 }
 
 void setupDingables() {
-  state.dingables = getChildDevices()?.findAll { RINGABLES.contains(it.getDataValue("kind")) }?.collect { getRingDeviceId(it.deviceNetworkId) }
+  state.dingables = getChildDevices()?.findAll { DINGABLES.contains(it.getDataValue("kind")) }?.collect { getRingDeviceId(it.deviceNetworkId) }
 }
 
 void configureDingPolling() {


### PR DESCRIPTION
There was a typo in the "dingables" detection which overly restricted what devices could be used for polling.  I noticed this when my Ring Stick Up camera was not included.